### PR TITLE
Adding the feature to create workload images locally and pass that to curated script

### DIFF
--- a/data/tests_without_attestation.yaml
+++ b/data/tests_without_attestation.yaml
@@ -3,6 +3,7 @@ default_input_args:
   attestation: n
   runtime_variables: n
   signing_key_path :
+  create_local_image: n
 
 test_redis_test_option:
   docker_image: redis/redis:latest
@@ -17,5 +18,10 @@ test_redis_with_runtime_variables:
   signing_key_path:
   runtime_variables: y
   runtime_variable_list: name="curator_app",version="1.2"
+
+test_redis_with_local_docker_image:
+  docker_image: redis/redis:latest
+  create_local_image: y
+  test_option: y
 
 

--- a/test/test_apps_without_attestation.py
+++ b/test/test_apps_without_attestation.py
@@ -19,3 +19,7 @@ class TestClass:
     def test_redis_with_runtime_variables(self):
         test_result = src.libs.curated_app_libs.run_test(self, tests_yaml_path)
         assert test_result == 0
+    
+    def test_redis_with_local_docker_image(self):
+        test_result = src.libs.curated_app_libs.run_test(self, tests_yaml_path)
+        assert test_result == 0


### PR DESCRIPTION
Added a new flag to denote whether the framework needs to create a local image or can pull from dockerhub. By default it will pull from dockerhub as that is the most important flow.

The flow has been tested for Redis but not for Pytorch.

Made some other minor improvements like renaming of `baseos` to `workload_image` and some changes to optimize the flow.
