### PR TITLE
Add encrypted_files_path key to pytorch_test_option

### DIFF
--- a/data/tests_without_attestation.yaml
+++ b/data/tests_without_attestation.yaml
@@ -166,6 +166,7 @@ test_pytorch_test_option:
   docker_image: pytorch pytorch-encrypted
   create_local_image: y
   test_option: y
+  encrypted_files_path: classes.txt:input.jpg:alexnet-pretrained.pt:result.txt
 
 test_pytorch_default:
   docker_image: pytorch pytorch-encrypted


### PR DESCRIPTION
pytorch_test_option get failed if gramine is not present in the system, gramine is only installed only if encrypted_files_path key is enabled 
http://ba5sapp0350:8080/view/Curation%20App/job/local_ci_curation_app_pytest_master/631/consoleFull